### PR TITLE
add UDP retries and compatible with python3.9

### DIFF
--- a/custom_components/hass_cozylife_local_pull/udp_discover.py
+++ b/custom_components/hass_cozylife_local_pull/udp_discover.py
@@ -35,6 +35,22 @@ def get_ip() -> list:
         server.sendto(bytes(message, encoding='utf-8'), ('255.255.255.255', 6095))
         time.sleep(0.03)
         i += 1
+
+    # max tries before first data received
+    max = 5
+    i = 0
+    while i < max:
+        i += 1
+        try:
+            data, addr = server.recvfrom(1024, socket.MSG_PEEK)
+        except Exception as err:
+            _LOGGER.info(f'{i}/{max} try, udp timeout')
+            continue
+        _LOGGER.info(f'first udp.receiver:{addr[0]}')
+        break
+    else:
+        _LOGGER.warning('cannot find any device')
+        return []
     
     i = 255
     ip = []

--- a/custom_components/hass_cozylife_local_pull/utils.py
+++ b/custom_components/hass_cozylife_local_pull/utils.py
@@ -40,7 +40,7 @@ def get_pid_list(lang='en') -> list:
         _LOGGER.info('get_pid_list.result is none')
         return []
     try:
-        pid_list = json.loads(res.content, encoding='utf-8')
+        pid_list = json.loads(res.content)
     except:
         _LOGGER.info('get_pid_list.result is not json')
         return []


### PR DESCRIPTION
Two commits:


python3.9's `json.loads` remove `encoding` argument. https://docs.python.org/3/library/json.html#json.loads
According to python doc, `json.loads` assumes input is UTF-8, UTF-16 or UTF-32. So encoding is unnecessary even before 3.9.



UDP is not stable. In my case, there are always timeouts before first data arrived. I use a `MSG_PEEK` to ensure it's ready.