### PR TITLE
Fix: Update platform loading for HA Core 2025.5+ compatibility

### DIFF
--- a/custom_components/hass_cozylife_local_pull/__init__.py
+++ b/custom_components/hass_cozylife_local_pull/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.typing import ConfigType
 import logging
 import time
@@ -49,7 +50,6 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     time.sleep(3)
     # _LOGGER.info('setup', hass, config)
     # hass.helpers.discovery.load_platform('sensor', DOMAIN, {}, config)
-    hass.helpers.discovery.load_platform('light', DOMAIN, {}, config)
-    hass.helpers.discovery.load_platform('switch', DOMAIN, {}, config)
-    
+    hass.loop.call_soon_threadsafe(hass.async_create_task, async_load_platform(hass, 'light', DOMAIN, {}, config))
+    hass.loop.call_soon_threadsafe(hass.async_create_task, async_load_platform(hass, 'switch', DOMAIN, {}, config))
     return True


### PR DESCRIPTION
This commit addresses compatibility issues with Home Assistant Core version 2025.5.0 and later, which removed the `hass.helpers` attribute, including `hass.helpers.discovery.load_platform`.

Previously, the integration used `hass.helpers.discovery.load_platform` to set up its light and switch platforms. This caused an `AttributeError: 'HomeAssistant' object has no attribute 'helpers'` after the update.

The fix involves:
1.  Replacing `hass.helpers.discovery.load_platform` with the current standard `homeassistant.helpers.discovery.async_load_platform`.
2.  Since the `setup` function in this integration is synchronous and runs in a separate thread, directly calling `hass.async_create_task` for `async_load_platform` would lead to a `RuntimeError` due to thread safety violations.
3.  To correctly schedule these asynchronous platform loads from the synchronous setup, `hass.loop.call_soon_threadsafe(hass.async_create_task, ...)` is now used. This ensures that the tasks are created and run within the Home Assistant event loop, maintaining thread safety.

These changes ensure the component can successfully load its platforms on newer Home Assistant versions.