### PR TITLE
Add network scanning script and device alias support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# CozyLife & Home Assistant 
+# CozyLife & Home Assistant
 
-CozyLife Assistant integration is developed for controlling CozyLife devices using local net, officially 
+CozyLife Assistant integration is developed for controlling CozyLife devices using local net, officially
 maintained by the CozyLife Team.
 
 
@@ -16,11 +16,62 @@ maintained by the CozyLife Team.
 * A home assistant environment that can access the external network
 * clone the repo to the custom_components directory
 * configuration.yaml
+
+### Configuration
+
+#### Step 1: Scan Your Network
+
+Use the provided scanning script to find all CozyLife devices on your network:
+
+```bash
+python3 scan_cozylife.py 192.168.123.0/24 192.168.123.0/24
 ```
+
+Or scan a specific range:
+```bash
+python3 scan_cozylife.py 192.168.123.130-170 192.168.123.130-170
+```
+
+The script will output a ready-to-use configuration block that you can copy-paste into your `configuration.yaml`.
+
+#### Step 2: Add Configuration to Home Assistant
+
+Copy the generated configuration into your `configuration.yaml`:
+
+```yaml
+hass_cozylife_local_pull:
+  lang: en
+  devices:
+    - serial_number: 767941640050c2edda8b
+      alias: Living Room Light
+      ip: 192.168.123.151
+    - serial_number: 629168597cb94c4c1d8f
+      alias: Bedroom Switch
+      ip: 192.168.123.158
+    - serial_number: 767953670050c2856f66
+      alias: Kitchen Light
+      ip: 192.168.123.159
+```
+
+**Configuration Fields:**
+- `lang` (optional): Language for device names. Default: `en`
+- `devices` (required): List of device configurations
+  - `serial_number` (required): The unique device serial number
+  - `alias` (required): Friendly name for the device in Home Assistant
+  - `ip` (required): IP address of the device
+
+**Note:** IP addresses must be hard-coded in the configuration. If a device's IP changes (e.g., due to DHCP), you'll need to rescan the network and update the configuration.
+
+#### Legacy Configuration (UDP Discovery + Explicit IPs)
+
+For backward compatibility, you can still use the old format:
+
+```yaml
 hass_cozylife_local_pull:
    lang: en
    ip:
      - "192.168.1.99"
+     - "192.168.1.100"
 ```
 
 
@@ -28,7 +79,7 @@ hass_cozylife_local_pull:
 * Please submit an issue
 * Send an email with the subject of hass support to info@cozylife.app
 
-### Troubleshoot 
+### Troubleshoot
 * Check whether the internal network isolation of the router is enabled
 * Check if the plugin is in the right place
 * Restart HASS multiple times

--- a/configuration_example.yaml
+++ b/configuration_example.yaml
@@ -1,0 +1,15 @@
+hass_cozylife_local_pull:
+  lang: en
+  devices:
+    - serial_number: 767941640050c2edda8b
+      alias: Switch_02
+      ip: 192.168.123.151
+    - serial_number: 767953670050c2856f66
+      alias: Switch_03
+      ip: 192.168.123.158
+    - serial_number: 767976720050c2d1fffb
+      alias: Switch_04
+      ip: 192.168.123.159
+    - serial_number: 767993670050c2e938a1
+      alias: Switch_05
+      ip: 192.168.123.160

--- a/custom_components/hass_cozylife_local_pull/__init__.py
+++ b/custom_components/hass_cozylife_local_pull/__init__.py
@@ -14,35 +14,91 @@ from .utils import get_pid_list
 from .udp_discover import get_ip
 from .tcp_client import tcp_client
 
-
 _LOGGER = logging.getLogger(__name__)
 
 
 def setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    
+
     """
-    TODO:timer discover
-    config:{'lang': 'zh', 'ip': ['192.168.5.201', '192.168.5.202', '192.168.5.1']}
-}
+    Setup CozyLife integration.
+    Supports config formats:
+    1. Legacy: {'lang': 'zh', 'ip': ['192.168.5.201', '192.168.5.202']}
+    2. New with list: {'lang': 'en', 'devices': [{'serial_number': '...', 'alias': '...', 'ip': '...'}]}
     """
-    ip = get_ip()
-    ip_from_config = config[DOMAIN].get('ip') if config[DOMAIN].get('ip') is not None else []    
-    ip += ip_from_config
+    config_data = config.get(DOMAIN, {})
+    lang_from_config = config_data.get('lang') if config_data.get('lang') is not None else LANG
+    get_pid_list(lang_from_config)
+
+    # Parse devices from config
+    device_configs = config_data.get('devices', {})
+    device_aliases = {}  # Maps device_id to alias
+    device_ips = {}  # Maps device_id to IP
+
+    if isinstance(device_configs, list):
+        # List format: [{'serial_number': '...', 'alias': '...', 'ip': '...'}, ...]
+        for item in device_configs:
+            if isinstance(item, dict):
+                # Check for new format: {'serial_number': '...', 'alias': '...', 'ip': '...'}
+                if 'serial_number' in item:
+                    device_id = item['serial_number']
+                    device_aliases[device_id] = item.get('alias', '')
+                    if 'ip' in item:
+                        device_ips[device_id] = item['ip']
+                    else:
+                        _LOGGER.warning(f'Device {device_id} missing IP address in config')
+                # Backward compat: support 'device_id' key
+                elif 'device_id' in item:
+                    device_id = item['device_id']
+                    device_aliases[device_id] = item.get('alias', '')
+                    if 'ip' in item:
+                        device_ips[device_id] = item['ip']
+                    else:
+                        _LOGGER.warning(f'Device {device_id} missing IP address in config')
+    elif isinstance(device_configs, dict):
+        # Dict format: {'SERIAL_NUMBER': 'ALIAS'} (backward compat, but requires IP in legacy 'ip' list)
+        device_aliases = device_configs.copy()
+
+    # Determine IP addresses to use
     ip_list = []
-    [ip_list.append(i) for i in ip if i not in ip_list]
+
+    # Use IPs from device configs (new format)
+    if device_ips:
+        ip_list = list(device_ips.values())
+        _LOGGER.info(f'Using IPs from device config: {ip_list}')
+    else:
+        # Legacy config: use UDP discovery + explicit IPs
+        _LOGGER.info('Using legacy UDP discovery + explicit IPs')
+        ip = get_ip()
+        ip_from_config = config_data.get('ip') if config_data.get('ip') is not None else []
+        ip += ip_from_config
+        [ip_list.append(i) for i in ip if i not in ip_list]
 
     if 0 == len(ip_list):
         _LOGGER.info('discover nothing')
         return True
 
-    _LOGGER.info('try conncet ip_list:', ip_list)
-    lang_from_config = (config[DOMAIN].get('lang') if config[DOMAIN].get('lang') is not None else LANG)
-    get_pid_list(lang_from_config)
+    _LOGGER.info(f'try connect ip_list: {ip_list}')
+
+    # Create tcp_client instances with aliases
+    # Create a reverse map: IP -> device_id for easier lookup
+    ip_to_device_id = {}
+    if device_ips:
+        for device_id, ip in device_ips.items():
+            ip_to_device_id[ip] = device_id
+
+    tcp_clients = []
+    for ip in ip_list:
+        # Find alias for this IP
+        alias = None
+        if ip in ip_to_device_id:
+            device_id = ip_to_device_id[ip]
+            alias = device_aliases.get(device_id)
+        tcp_clients.append(tcp_client(ip, alias=alias))
 
     hass.data[DOMAIN] = {
         'temperature': 24,
         'ip': ip_list,
-        'tcp_client': [tcp_client(item) for item in ip_list],
+        'tcp_client': tcp_clients,
     }
 
     #wait for get device info from tcp conncetion

--- a/scan_cozylife.py
+++ b/scan_cozylife.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Simple script to scan IP range for CozyLife devices.
+Usage: python scan_cozylife.py <IP_RANGE>
+Example: python scan_cozylife.py 192.168.123.0/24
+         python scan_cozylife.py 192.168.123.1-254
+"""
+
+import socket
+import json
+import time
+import sys
+import ipaddress
+
+
+def get_sn():
+    """Generate message serial number (timestamp)"""
+    return str(int(round(time.time() * 1000)))
+
+
+def check_cozylife_device(ip, port=5555, timeout=2):
+    """
+    Check if an IP address is a CozyLife device.
+    Returns device info dict if found, None otherwise.
+    """
+    try:
+        # Connect to device
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+        sock.connect((ip, port))
+
+        # Send CMD_INFO command
+        message = {
+            'cmd': 0,
+            'pv': 0,
+            'sn': get_sn(),
+            'msg': {}
+        }
+        payload = json.dumps(message, separators=(',', ':')) + "\r\n"
+        sock.send(payload.encode('utf-8'))
+
+        # Receive response
+        response = sock.recv(1024).decode('utf-8').strip()
+        sock.close()
+
+        # Parse response
+        resp_json = json.loads(response)
+
+        # Check if it's a valid CozyLife device response
+        if (resp_json.get('msg') and
+            isinstance(resp_json['msg'], dict) and
+            resp_json['msg'].get('did') and
+            resp_json['msg'].get('pid')):
+            return resp_json['msg']
+
+    except (socket.timeout, socket.error, json.JSONDecodeError, KeyError) as e:
+        pass
+
+    return None
+
+
+def parse_ip_range(ip_range):
+    """
+    Parse IP range string into list of IP addresses.
+    Supports CIDR notation (192.168.1.0/24) or range (192.168.1.1-254)
+    """
+    ips = []
+
+    # Try CIDR notation first
+    if '/' in ip_range:
+        try:
+            network = ipaddress.ip_network(ip_range, strict=False)
+            ips = [str(ip) for ip in network.hosts()]
+        except ValueError:
+            print(f"Error: Invalid CIDR notation: {ip_range}")
+            sys.exit(1)
+
+    # Try range notation (e.g., 192.168.1.1-254)
+    elif '-' in ip_range:
+        try:
+            base_ip, end = ip_range.rsplit('.', 1)
+            start_part, end_part = end.split('-')
+            base_parts = base_ip.split('.')
+
+            if len(base_parts) != 3:
+                raise ValueError("Invalid range format")
+
+            start = int(start_part)
+            end_val = int(end_part)
+
+            for i in range(start, end_val + 1):
+                ips.append(f"{base_ip}.{i}")
+        except (ValueError, IndexError):
+            print(f"Error: Invalid range notation: {ip_range}")
+            sys.exit(1)
+
+    # Single IP
+    else:
+        try:
+            ipaddress.ip_address(ip_range)
+            ips = [ip_range]
+        except ValueError:
+            print(f"Error: Invalid IP address: {ip_range}")
+            sys.exit(1)
+
+    return ips
+
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: python scan_cozylife.py <IP_RANGE>")
+        print("Examples:")
+        print("  python scan_cozylife.py 192.168.123.0/24")
+        print("  python scan_cozylife.py 192.168.123.1-254")
+        print("  python scan_cozylife.py 192.168.123.151")
+        sys.exit(1)
+
+    ip_range = sys.argv[1]
+    ips = parse_ip_range(ip_range)
+
+    print(f"Scanning {len(ips)} IP addresses for CozyLife devices...")
+    print()
+
+    found_devices = []
+
+    for ip in ips:
+        print(f"Checking {ip}...", end=' ', flush=True)
+        device_info = check_cozylife_device(ip)
+
+        if device_info:
+            print("✓ FOUND")
+            found_devices.append((ip, device_info))
+            print(f"  Serial Number: {device_info.get('did', 'N/A')}")
+            print(f"  Product ID: {device_info.get('pid', 'N/A')}")
+            print(f"  MAC: {device_info.get('mac', 'N/A')}")
+            print(f"  IP: {device_info.get('ip', ip)}")
+            print()
+        else:
+            print("✗")
+
+    print()
+    print(f"Scan complete. Found {len(found_devices)} CozyLife device(s)")
+    print()
+
+    if found_devices:
+        print("# Copy-paste this into your configuration.yaml:")
+        print("hass_cozylife_local_pull:")
+        print("  lang: en")
+        print("  devices:")
+        for ip, info in found_devices:
+            serial_number = info.get('did', 'N/A')
+            print(f"    - serial_number: {serial_number}")
+            print(f"      alias: Device_{serial_number[-4:]}")
+            print(f"      ip: {ip}")
+        print()
+    else:
+        print("No devices found.")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Everything should be non-breaking backward-compatible changes
- Add scan_cozylife.py standalone script for manual device discovery
- Support device aliases in configuration (serial_number format)
- Simplify implementation: use hard-coded IPs from config
- Remove cache and auto-scanning features
- Update README with scanning workflow
- Rename device_id to serial_number to avoid HA conflicts